### PR TITLE
fix(image-carousel): remove aria warning for the dialog

### DIFF
--- a/components/commerce-ui/image-carousel/basic/image-carousel-basic.tsx
+++ b/components/commerce-ui/image-carousel/basic/image-carousel-basic.tsx
@@ -6,6 +6,7 @@ import {
   Dialog,
   DialogClose,
   DialogContent,
+  DialogDescription,
   DialogOverlay,
   DialogPortal,
   DialogTitle,
@@ -84,6 +85,9 @@ const ImageContainer: React.FC<{
             <DialogTitle className="sr-only">
               {image.title || "Image"}
             </DialogTitle>
+            <DialogDescription className="sr-only">
+              {image.title || "Image"}
+            </DialogDescription>
 
             <div className="relative flex h-screen w-screen items-center justify-center">
               <TransformWrapper


### PR DESCRIPTION
When open the dialogue, there is a warning: 

Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.